### PR TITLE
Integrate ClangFormat to Format C++ Code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: Google
+ColumnLimit: 0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,9 @@ jobs:
       - name: Check Formatting
         uses: dprint/check@v2.3
 
+      - name: Check C++ Formatting
+        run: find . -name '*.cpp' -exec clang-format --dry-run --Werror {} +
+
       - name: Check Lint
         run: uv run ruff check
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+!.clang-format
 !.git*
 !.python-version
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,6 +7,10 @@ pre-commit:
     - name: fix formatting
       run: dprint fmt
 
+    - name: fix C++ formatting
+      files: find . -name *.cpp
+      run: clang-format -i {files}
+
     - name: fix lint
       run: uv run ruff check --fix
 


### PR DESCRIPTION
This pull request resolves #4 by integrating [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) to format C++ source code in this project.