### PR TITLE
Disable Fail Fast in CI Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,6 +37,7 @@ jobs:
     name: Build Wheels
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-24.04


### PR DESCRIPTION
This pull request resolves #9 by disabling fail fast in the CI workflow.