### PR TITLE
Remove CI Build on macOS 13

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
           - ubuntu-24.04-arm
           - windows-2022
           - windows-11-arm
-          - macos-13
+          - macos-15-intel
           - macos-15
     steps:
       - name: Checkout


### PR DESCRIPTION
This pull request resolves #79 by removing the `build.yaml` workflow from building on macOS 13, replacing it with macOS 15 Intel which use x64 architecture.